### PR TITLE
Fix destructor example for rust

### DIFF
--- a/code/rust/class_struct.rs
+++ b/code/rust/class_struct.rs
@@ -8,9 +8,11 @@ impl MyClass {
 	pub fn new(field: isize) -> MyClass {
 		MyClass { my_field: field }
 	}
+}
 
+impl Drop for MyClass {
 	// destructor
-	pub fn drop(&self) {
+	fn drop(&mut self) {
 	}
 }
 // END_CODE


### PR DESCRIPTION
The old code was just a normal method named drop, not a destructor. You need to use the Drop trait for it to work.
